### PR TITLE
Fix trusted domain duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [0.4.2] - 10/24/2024
+### Fixed
+- Addressed [#12](https://github.com/coffeegist/bofhound/issues/12), an issue with duplicate trusted domain objects
+
 ## [0.4.1] - 10/22/2024
 ### Fixed
 - Addressed [#10](https://github.com/coffeegist/bofhound/issues/10), an issue with the `ContainedBy` attribute in output JSON

--- a/bofhound/ad/adds.py
+++ b/bofhound/ad/adds.py
@@ -133,7 +133,18 @@ class ADDS():
                 # grab domain trusts
                 elif 'trustedDomain' in object_class:
                     bhObject = BloodHoundDomainTrust(object)
-                    bhObject.set_temporary_sid(len(self.trusts))
+
+                    # try to find if this domain is new or not
+                    needs_temp_sid = True
+                    for trust in self.trusts:
+                        if trust.TrustProperties['TargetDomainName'].upper() == bhObject.TrustProperties['TargetDomainName'].upper():
+                            bhObject.TrustProperties['TargetDomainSid'] = trust.TrustProperties['TargetDomainSid']
+                            needs_temp_sid = False
+
+                    # set a temporary sid if new trusted domain
+                    if needs_temp_sid:
+                        bhObject.set_temporary_sid(len(self.trusts))
+                        
                     target_list = self.trusts
                 # grab OUs
                 elif 'top, organizationalUnit' in object_class:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bofhound"
-version = "0.4.1"
+version = "0.4.2"
 description = "Parse output from common sources and transform it into BloodHound-ingestible data"
 authors = [
 	"Adam Brown",


### PR DESCRIPTION
Fix #12. That same trust mesh shown in the issue is parsed by this branch correctly
![image](https://github.com/user-attachments/assets/c7cdbca2-5b9d-4dd0-ae34-810c6a8be266)
