### PR TITLE
Improve handling of domain objects and their trust relationships

### DIFF
--- a/bofhound/ad/adds.py
+++ b/bofhound/ad/adds.py
@@ -142,18 +142,6 @@ class ADDS():
                 # grab domain trusts
                 elif 'trustedDomain' in object_class:
                     bhObject = BloodHoundDomainTrust(object)
-
-                    # try to find if this domain is new or not
-                    needs_temp_sid = True
-                    for trust in self.trusts:
-                        if trust.TrustProperties['TargetDomainName'].upper() == bhObject.TrustProperties['TargetDomainName'].upper():
-                            bhObject.TrustProperties['TargetDomainSid'] = trust.TrustProperties['TargetDomainSid']
-                            needs_temp_sid = False
-
-                    # set a temporary sid if new trusted domain
-                    if needs_temp_sid:
-                        bhObject.set_temporary_sid(len(self.trusts))
-                        
                     target_list = self.trusts
                 # grab OUs
                 elif 'top, organizationalUnit' in object_class:

--- a/bofhound/ad/adds.py
+++ b/bofhound/ad/adds.py
@@ -135,9 +135,10 @@ class ADDS():
                 object_class = object.get(ADDS.AT_OBJECTCLASS, '')
                 # if 'top, domain' in object_class or 'top, builtinDomain' in object_class:
                 if 'top, domain' in object_class:
-                    bhObject = BloodHoundDomain(object)
-                    self.add_domain(bhObject)
-                    target_list = self.domains
+                    if 'objectsid' in object.keys():
+                        bhObject = BloodHoundDomain(object)
+                        self.add_domain(bhObject)
+                        target_list = self.domains
                 # grab domain trusts
                 elif 'trustedDomain' in object_class:
                     bhObject = BloodHoundDomainTrust(object)

--- a/bofhound/ad/models/bloodhound_domaintrust.py
+++ b/bofhound/ad/models/bloodhound_domaintrust.py
@@ -3,6 +3,7 @@ from bofhound.ad.models.bloodhound_object import BloodHoundObject
 from bloodhound.ad.utils import ADUtils
 from bloodhound.ad.trusts import ADDomainTrust
 from bofhound.ad.helpers import TrustType, TrustDirection
+from impacket.ldap.ldaptypes import LDAP_SID
 import logging
 
 class BloodHoundDomainTrust(object):
@@ -23,27 +24,19 @@ class BloodHoundDomainTrust(object):
         self.TrustProperties = None
 
         if 'distinguishedname' in object.keys() and 'trustpartner' in object.keys() and \
-            'trustdirection' in object.keys() and 'trusttype' in object.keys() and 'trustattributes' in object.keys():
+            'trustdirection' in object.keys() and 'trusttype' in object.keys() and 'trustattributes' in object.keys() and \
+            'securityidentifier' in object.keys():
             
             self.LocalDomainDn = BloodHoundObject.get_domain_component(object.get('distinguishedname')).upper()
             trust_partner = object.get('trustpartner').upper()
             domain = ADUtils.ldap2domain(object.get('distinguishedname')).upper()
             logging.debug(f'Reading trust relationship between {ColorScheme.domain}{domain}[/] and {ColorScheme.domain}{trust_partner}[/]', extra=OBJ_EXTRA_FMT)
-            trust = ADDomainTrust(trust_partner, int(object.get('trustdirection')), object.get('trusttype'), int(object.get('trustattributes')), '')
+            domainsid = LDAP_SID()
+            domainsid.fromCanonical(object.get('securityidentifier'))
+            trust = ADDomainTrust(trust_partner, int(object.get('trustdirection')), object.get('trusttype'), int(object.get('trustattributes')), domainsid.getData())
             self.TrustProperties = trust.to_output()
 
             # BHCE now wants trusttype and direction defined as string names instead of int values
             
             self.TrustProperties['TrustDirection'] = TrustDirection(self.TrustProperties['TrustDirection']).name
             self.TrustProperties['TrustType'] = TrustType(self.TrustProperties['TrustType']).name
-
-    # Leaving the sid property blank, or setting it to a static value causes 
-    # BloodHound to improperly display trusts. Each trusted domain seems to 
-    # require a unique SID
-    def set_temporary_sid(self, indx):
-        self.TrustProperties['TargetDomainSid'] = f'S-1-5-21-{indx}'
-
-
-
-
-


### PR DESCRIPTION
Last year I spend some time comparing the graph produced by BOFHound with the one from the standard SharpHound ingestor.

My approach was to provide as much data as possible to BOFHound by querying every single LDAP object in every naming context (i.e. certainly not what you would do in a red teaming setting).

This pull request addresses some difference I observed in the context of domain objects and their trust relationship.

 - Domain objects related to ADIDNS without an `objectsid` attribute are ignored
 - Target domains of trusts are determinded by the `securityIdentifier` of the `trustedDomain` object. This relies on proper parsing of the underlying LDAP attribute, see corresponding changes to [pyldapsearch](https://github.com/Tw1sm/pyldapsearch/pull/4) and the [ldapsearch BOF](https://github.com/trustedsec/CS-Situational-Awareness-BOF/pull/126). This essentially reverts #14, but should still fix #12 or at least I get the correct trust relationships:

![image](https://github.com/user-attachments/assets/5fbc6637-648f-4dd3-a40f-8d585b32abe9)


