### PR TITLE
Allow schemaIDGUID to be formatted as UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 ## [0.4.7] - 04/29/2025
+### Added
+- Ability to handle schemaIdGuids from ADExplorer LDIF output
+
 ### Fixed
 - Improved fix for [#12](https://github.com/coffeegist/bofhound/issues/12) by keying on the `securityIdentifier` attribute on trust objects
 

--- a/bofhound/ad/models/bloodhound_schema.py
+++ b/bofhound/ad/models/bloodhound_schema.py
@@ -12,7 +12,11 @@ class BloodHoundSchema(object):
 		if 'name' in object.keys() and 'schemaidguid' in object.keys():
 			self.Name = object.get('name').lower()
 			try:
-				self.SchemaIdGuid = str(UUID(bytes_le=base64.b64decode(object.get('schemaidguid')))).lower()
+				value = object.get('schemaidguid')
+				if '-' in value:
+					self.SchemaIdGuid = value.lower()
+				else:
+					self.SchemaIdGuid = str(UUID(bytes_le=base64.b64decode(value))).lower()
 				logging.debug(f"Reading Schema object {ColorScheme.schema}{self.Name}[/]", extra=OBJ_EXTRA_FMT)
 			except:
 				logging.warning(f"Error base64 decoding SchemaIDGUID attribute on Schema {ColorScheme.schema}{self.Name}[/]", extra=OBJ_EXTRA_FMT)

--- a/tests/ad/test_adds.py
+++ b/tests/ad/test_adds.py
@@ -104,6 +104,13 @@ def test_import_objects_singleSchema():
     assert len(adds.schemas) == 1
 
 
+def test_import_objects_singleSchema_ldif():
+    adds = ADDS()
+    adds.import_objects([{ADDS.AT_SCHEMAIDGUID: '45b01500-c419-11d1-bbc9-0080c76670c0', ADDS.AT_NAME: 'ANR'}])
+
+    assert len(adds.schemas) == 1
+
+
 def test_import_objects_noAccountType(raw_user):
     adds = ADDS()
     raw_user.pop(ADDS.AT_SAMACCOUNTTYPE)


### PR DESCRIPTION
This allows parsing of AD explorer originated LDIF output without a round trip through base64. The base64 encoded version remains supported, for usage with other tools.