### PR TITLE
Fix: Prevent KeyError when 'operatingsystem' is missing during service pack append

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [0.4.8] - 5/5/2025
+### Fixed
+- Check for `operatingsystemservicepack` property to prevent key error - [merge #30](https://github.com/coffeegist/bofhound/pull/30)
+
 ## [0.4.7] - 04/29/2025
 ### Added
 - Ability to handle schemaIdGuids from ADExplorer LDIF output

--- a/bofhound/ad/models/bloodhound_computer.py
+++ b/bofhound/ad/models/bloodhound_computer.py
@@ -69,7 +69,7 @@ class BloodHoundComputer(BloodHoundObject):
         if 'operatingsystem' in object.keys():
             self.Properties['operatingsystem'] = object.get('operatingsystem', 'Unknown')
 
-        if 'operatingsystemservicepack' in object.keys():
+        if 'operatingsystemservicepack' in object.keys() and 'operatingsystem' in self.Properties:
             self.Properties['operatingsystem'] += f' {object.get("operatingsystemservicepack")}'
 
         if 'sidhistory' in object.keys():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bofhound"
-version = "0.4.7"
+version = "0.4.8"
 description = "Parse output from common sources and transform it into BloodHound-ingestible data"
 authors = [
 	"Adam Brown",


### PR DESCRIPTION
Fixes a KeyError that occurred when attempting to append `operatingsystemservicepack` if the base `operatingsystem` key was not already present in `self.Properties`.
The code now checks for the existence of `self.Properties['operatingsystem']` before attempting the append operation.