### PR TITLE
fix: Ensure self.certtemplates exists before iterating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
-## [0.4.8] - 5/5/2025
+## [0.4.8] - 5/12/2025
 ### Fixed
 - Check for `operatingsystemservicepack` property to prevent key error - [merge #30](https://github.com/coffeegist/bofhound/pull/30)
+- Check for `CertTemplates` property to prevent type error - [merge #31](https://github.com/coffeegist/bofhound/pull/31)
 
 ## [0.4.7] - 04/29/2025
 ### Added

--- a/bofhound/ad/adds.py
+++ b/bofhound/ad/adds.py
@@ -660,11 +660,12 @@ class ADDS():
 
 
     def resolve_published_templates(self, entry:BloodHoundEnterpriseCA):
-        for template_name in entry.CertTemplates :
-            for template in self.certtemplates:
-                if template.Properties['name'].split('@')[0].lower() == template_name.lower() \
-                and template.Properties['domain'] == entry.Properties['domain']:
-                    entry.EnabledCertTemplates.append({"ObjectIdentifier": template.ObjectIdentifier.upper(), "ObjectType": "CertTemplate"})
+        if hasattr(entry, 'CertTemplates') and entry.CertTemplates:
+            for template_name in entry.CertTemplates :
+                for template in self.certtemplates:
+                    if template.Properties['name'].split('@')[0].lower() == template_name.lower() \
+                    and template.Properties['domain'] == entry.Properties['domain']:
+                        entry.EnabledCertTemplates.append({"ObjectIdentifier": template.ObjectIdentifier.upper(), "ObjectType": "CertTemplate"})
 
 
     # Returns int: number of relations parsed


### PR DESCRIPTION
When processing Enterprise CAs, the code attempts to iterate over entry.CertTemplates to find matches for published templates. If no certificate template objects were collected from the input logs, this list could be None or empty, leading to a TypeError.