### PR TITLE
objectguids to uppercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [0.4.11] - 7/24/2025
+### Fixed
+- Modified ObjectIdentifier/ObjectGuid properties to be uppercase so object correlation in BHCE happens correctly
+
 ## [0.4.10] - 7/9/2025
 ### Changed
 - Targeted logfile name syntax changed to be more generic (no longer tied to pyldapsearch) to work with SoaPy

--- a/bofhound/ad/adds.py
+++ b/bofhound/ad/adds.py
@@ -279,7 +279,7 @@ class ADDS():
                     if type_contained == "":
                         for obj in self.unknown_objects:
                             if str(obj.get('distinguishedname')).upper() == contained_dn:
-                                id_contained = obj.get('objectguid')
+                                id_contained = obj.get("objectguid").upper()
                                 match obj.get('objectclass'):
                                     case 'top, NTDSService':
                                         type_contained = "Base"

--- a/bofhound/ad/models/bloodhound_aiaca.py
+++ b/bofhound/ad/models/bloodhound_aiaca.py
@@ -25,7 +25,7 @@ class BloodHoundAIACA(BloodHoundObject):
         self.x509Certificate = None
 
         if 'objectguid' in object.keys():
-            self.ObjectIdentifier = object.get("objectguid")
+            self.ObjectIdentifier = object.get("objectguid").upper()
 
         if 'distinguishedname' in object.keys():
             domain = ADUtils.ldap2domain(object.get('distinguishedname')).upper()

--- a/bofhound/ad/models/bloodhound_certtemplate.py
+++ b/bofhound/ad/models/bloodhound_certtemplate.py
@@ -33,7 +33,7 @@ class BloodHoundCertTemplate(BloodHoundObject):
         self.cas_ids = []
 
         if 'objectguid' in object.keys():
-            self.ObjectIdentifier = object.get("objectguid")
+            self.ObjectIdentifier = object.get("objectguid").upper()
 
         if 'distinguishedname' in object.keys():
             domain = ADUtils.ldap2domain(object.get('distinguishedname')).upper()

--- a/bofhound/ad/models/bloodhound_container.py
+++ b/bofhound/ad/models/bloodhound_container.py
@@ -20,7 +20,7 @@ class BloodHoundContainer(BloodHoundObject):
         self.Properties["blocksinheritance"] = False
 
         if 'objectguid' in object.keys():
-            self.ObjectIdentifier = object.get('objectguid').upper()
+            self.ObjectIdentifier = object.get("objectguid").upper().upper()
         
         if 'distinguishedname' in object.keys() and 'ou' in object.keys():
             self.Properties["domain"] = ADUtils.ldap2domain(object.get('distinguishedname').upper())

--- a/bofhound/ad/models/bloodhound_enterpriseca.py
+++ b/bofhound/ad/models/bloodhound_enterpriseca.py
@@ -33,7 +33,7 @@ class BloodHoundEnterpriseCA(BloodHoundObject):
         self.x509Certificate = None
 
         if 'objectguid' in object.keys():
-            self.ObjectIdentifier = object.get("objectguid")
+            self.ObjectIdentifier = object.get("objectguid").upper()
 
         if 'distinguishedname' in object.keys():
             domain = ADUtils.ldap2domain(object.get('distinguishedname')).upper()

--- a/bofhound/ad/models/bloodhound_gpo.py
+++ b/bofhound/ad/models/bloodhound_gpo.py
@@ -27,7 +27,7 @@ class BloodHoundGPO(BloodHoundObject):
             logger.debug(f"Reading GPO object {ColorScheme.gpo}{self.Properties['name']}[/]", extra=OBJ_EXTRA_FMT)
 
         if 'objectguid' in object.keys():
-            self.ObjectIdentifier = object.get('objectguid').upper()
+            self.ObjectIdentifier = object.get("objectguid").upper().upper()
 
         if 'ntsecuritydescriptor' in object.keys():
             self.RawAces = object['ntsecuritydescriptor']

--- a/bofhound/ad/models/bloodhound_issuancepolicy.py
+++ b/bofhound/ad/models/bloodhound_issuancepolicy.py
@@ -27,7 +27,7 @@ class BloodHoundIssuancePolicy(BloodHoundObject):
         self.GroupLink = None # {}
 
         if 'objectguid' in object.keys():
-            self.ObjectIdentifier = object.get("objectguid")
+            self.ObjectIdentifier = object.get("objectguid").upper()
 
         if 'distinguishedname' in object.keys():
             domain = ADUtils.ldap2domain(object.get('distinguishedname')).upper()

--- a/bofhound/ad/models/bloodhound_ntauthstore.py
+++ b/bofhound/ad/models/bloodhound_ntauthstore.py
@@ -28,7 +28,7 @@ class BloodHoundNTAuthStore(BloodHoundObject):
         self.Properties['certthumbprints'] = []
 
         if 'objectguid' in object.keys():
-            self.ObjectIdentifier = object.get("objectguid")
+            self.ObjectIdentifier = object.get("objectguid").upper()
 
         if 'distinguishedname' in object.keys():
             domain = ADUtils.ldap2domain(object.get('distinguishedname')).upper()

--- a/bofhound/ad/models/bloodhound_ou.py
+++ b/bofhound/ad/models/bloodhound_ou.py
@@ -29,7 +29,7 @@ class BloodHoundOU(BloodHoundObject):
             logger.debug(f"Reading OU object {ColorScheme.ou}{self.Properties['name']}[/]", extra=OBJ_EXTRA_FMT)
 
         if 'objectguid' in object.keys():
-            self.ObjectIdentifier = object.get('objectguid').upper()
+            self.ObjectIdentifier = object.get("objectguid").upper().upper()
 
         if 'ntsecuritydescriptor' in object.keys():
             self.RawAces = object['ntsecuritydescriptor']

--- a/bofhound/ad/models/bloodhound_rootca.py
+++ b/bofhound/ad/models/bloodhound_rootca.py
@@ -25,7 +25,7 @@ class BloodHoundRootCA(BloodHoundObject):
         self.x509Certificate = None
 
         if 'objectguid' in object.keys():
-            self.ObjectIdentifier = object.get("objectguid")
+            self.ObjectIdentifier = object.get("objectguid").upper()
 
         if 'distinguishedname' in object.keys():
             domain = ADUtils.ldap2domain(object.get('distinguishedname')).upper()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bofhound"
-version = "0.4.10"
+version = "0.4.11"
 description = "Parse output from common sources and transform it into BloodHound-ingestible data"
 authors = [
 	"Adam Brown",


### PR DESCRIPTION
Fix an error with ADCS objects not appearing correctly in the BHCE UI due to Object GUIDs not being uppercase