### PR TITLE
OC2: prevent crashing on errored tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [0.4.25] - 4/25/2026
+### Fixes
+- Fixed issue causing crash if OC2 task did not recieve output [#60](https://github.com/coffeegist/bofhound/pull/60)
+
 ## [0.4.24] - 3/31/2026
 ### Added
 - Support for LAPSv2 [#58](https://github.com/coffeegist/bofhound/pull/58)

--- a/bofhound/parsers/data_sources.py
+++ b/bofhound/parsers/data_sources.py
@@ -95,6 +95,10 @@ class OutflankDataStream(FileDataStream):
                     and event_json['task']['name'].lower() == bofname):
                     # now we have a block of ldapsearch data we can parse through for objects
                     response_lines = event_json['task']['response']
+
+                    if response_lines is None:
+                        continue
+
                     for response_line in response_lines.splitlines():
                         yield response_line
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bofhound"
-version = "0.4.24"
+version = "0.4.25"
 description = "Parse output from common sources and transform it into BloodHound-ingestible data"
 authors = [
 	"Adam Brown",


### PR DESCRIPTION
During an operation with OC2, we noticed that if an `ldapsearch` task errors, the `response` can be `null`:

<img width="2439" height="124" alt="image" src="https://github.com/user-attachments/assets/144ccddf-a1ca-4e98-9de6-62e626e2699d" />

The state looks like this within OC2:
<img width="2605" height="200" alt="Screenshot 2026-04-10 182424" src="https://github.com/user-attachments/assets/8dcdaeeb-91a7-49a5-84e4-37baa571373c" />

Bofhound did not yet take this into account and assumed the response value is always a string, resulting in the following error when attempting to parse our implant's log:
<img width="2332" height="248" alt="image" src="https://github.com/user-attachments/assets/0c99e25a-5485-4022-97ba-729010b6fe30" />

I added a small guard to check if the parsed value is not None, to prevent an errored task from crashing Bofhound.